### PR TITLE
access to intent names, click registers once

### DIFF
--- a/client/src/pages/Dashboard/components/ForceGraph.js
+++ b/client/src/pages/Dashboard/components/ForceGraph.js
@@ -7,20 +7,26 @@ export default function ForceGraph({ nodes }, maxRadius) {
 
   // re-create animation every time nodes change
   useEffect(() => {
-    
+
+    // const onClick = (e) => {
+    //   console.log(e.target.id)
+    // }
+
+    // window.addEventListener('mouseup', onClick)
+
     const simulation = d3
       .forceSimulation()
       .force("x", d3.forceX(960))
       .force("y", d3.forceY(500))
       .force("collide", d3.forceCollide().radius(d => d.r + 1));
-      // .force("collision", d3.forceCollide(/* Will take in value passed to maxRadius*/ 60));
+    // .force("collision", d3.forceCollide(/* Will take in value passed to maxRadius*/ 60));
 
 
     // update state on every frame
     simulation.on("tick", () => {
       setAnimatedNodes([...simulation.nodes()]);
     });
-    
+
     // copy nodes into simulation
     simulation.nodes([...nodes]);
     // slow down with a small alpha
@@ -29,26 +35,31 @@ export default function ForceGraph({ nodes }, maxRadius) {
     // stop simulation on unmount
     return () => simulation.stop();
 
+
   }, [nodes]);
 
-  window.addEventListener("mouseup", (e) => {
-    const color = Math.round(Math.random() * 0xffffff);
-    const fill = `#${color.toString(16).padStart(6, "0")}`;
-    e.target.style.fill = fill;
-  });
-  
+  // window.addEventListener("mouseup", (e) => {
+
+  //   console.log(e.target.id)
+  // });
+
+  const onClick = (e) => {
+    console.log(e.target.id)
+  }
 
   return (
-    <svg className = "button">
+    <svg className="button">
       {animatedNodes.map((node) => (
-        <circle 
+        <circle
           cx={node.x}
           cy={node.y}
           r={node.r}
           key={node.id}
           stroke="black"
           fill={RandomColor()}
-          pointer-events="visiblePainted"
+          pointerEvents="visiblePainted"
+          id={node.id}
+          onClick={onClick}
         />
       ))}
     </svg>


### PR DESCRIPTION
The earlier d3 bugs are solved.

- Clicks on circles register once.
- We have access to which circle represents which intent.

After this merge, we are ready to start working on the modal and integration with voiceflow.