### PR TITLE
User invalid email bug fixed

### DIFF
--- a/client/src/pages/LandingPage/components/Register.js
+++ b/client/src/pages/LandingPage/components/Register.js
@@ -3,7 +3,7 @@ import axios from 'axios'
 
 class Register extends React.Component {
 
-    constructor(){
+    constructor() {
         super()
         this.state = {
             email: "",
@@ -11,36 +11,35 @@ class Register extends React.Component {
         }
     }
 
-    onEmailUpdate = (e) =>{
+    onEmailUpdate = (e) => {
         const email = e.target.value;
-        this.setState(()=>{
-            return {email}
+        this.setState(() => {
+            return { email }
         })
     }
 
-    onPasswordUpdate = (e) =>{
+    onPasswordUpdate = (e) => {
         const password = e.target.value;
-        this.setState(()=>{
-            return{password}
+        this.setState(() => {
+            return { password }
         })
     }
 
-    onFormSubmit = (e) =>{
+    onFormSubmit = (e) => {
         e.preventDefault()
         const url = `http://localhost:8080/createUser`
-        axios.post(url, {"email": this.state.email, "password": this.state.password}).then(async (res)=>{
-            if(res.status === 200){
-                alert("User with email " + this.state.email + " has been created.")
-                this.setState(()=>{
-                    return({
-                        email: "",
-                        password: ""
-                    })
+        axios.post(url, { "email": this.state.email, "password": this.state.password }).then(async (res) => {
+
+            alert("User with email " + this.state.email + " has been created.")
+            this.setState(() => {
+                return ({
+                    email: "",
+                    password: ""
                 })
-            }
-            else{
-                alert("Error")
-            }
+            })
+
+        }).catch((e) => {
+            alert('Invalid email')
         })
     }
 
@@ -48,16 +47,16 @@ class Register extends React.Component {
         return (
             <div>
                 <h2>Register</h2>
-                <form onSubmit = {this.onFormSubmit}>
+                <form onSubmit={this.onFormSubmit}>
                     <div className="input">
-                        <input type="text" id="login-email-input" className="input-text" placeholder="Your email, e.g. MrWonderful@cs.toronto.edu" 
-                        value = {this.state.email} onChange = {this.onEmailUpdate}/>
+                        <input type="text" id="login-email-input" className="input-text" placeholder="Your email, e.g. MrWonderful@cs.toronto.edu"
+                            value={this.state.email} onChange={this.onEmailUpdate} />
                         <label htmlFor="login-email-input" className="input-label">Email</label>
                     </div>
                     <br></br>
                     <div className="input">
-                        <input type="password" id="login-password-input" className="input-text" placeholder="Your password, e.g. #Wonderful123" 
-                        value = {this.state.password} onChange = {this.onPasswordUpdate}/>
+                        <input type="password" id="login-password-input" className="input-text" placeholder="Your password, e.g. #Wonderful123"
+                            value={this.state.password} onChange={this.onPasswordUpdate} />
                         <label htmlFor="login-password-input" className="input-label">Password</label>
                     </div>
                     <br></br>

--- a/server/src/Controllers/userRegisterController.js
+++ b/server/src/Controllers/userRegisterController.js
@@ -14,7 +14,7 @@ router.post('/createUser', jsonParser, async (req, res) => {
         res.send(user)
     }
     catch (e) {
-        res.send("Unable to register.")
+        res.sendStatus(422)
     }
 })
 


### PR DESCRIPTION
Earlier, if the user tried to create an account with email 'a', they would get the message User with email 'a' has been created. Even though @aidanmrli wrote code on the backend to reject such requests, it was not reflected on the client side. 

Now, the user will get 'invalid email' if they try to create an account with emails like 'a'.