### PR TITLE
Same filename issue

### DIFF
--- a/client/src/pages/Dashboard/components/FileSystem.js
+++ b/client/src/pages/Dashboard/components/FileSystem.js
@@ -48,7 +48,7 @@ export default function FileSystem() {
             setFileUploadStatus("File " + selectedFile.name + " has been upload successfully.")
             setFiles(oldFiles => [...oldFiles, selectedFile.name])
         }).catch((error) => {
-            alert("Error uploading file")
+            alert(error.response.data)
         })
     }
 

--- a/client/src/pages/Dashboard/components/FileSystem.js
+++ b/client/src/pages/Dashboard/components/FileSystem.js
@@ -35,7 +35,7 @@ export default function FileSystem() {
             }
             setFiles(dataSoFar)
         }).catch((error) => {
-            alert(error)
+            alert("Error getting transcripts")
         })
 
     }
@@ -46,10 +46,10 @@ export default function FileSystem() {
         data.append('file', selectedFile, selectedFile.name)
         axios.post("http://localhost:8080/uploadTranscript", data, { headers: { "Authorization": "Bearer " + token } }).then(async (res) => {
             setFileUploadStatus("File " + selectedFile.name + " has been upload successfully.")
+            setFiles(oldFiles => [...oldFiles, selectedFile.name])
         }).catch((error) => {
-            alert("Not Authenticated")
+            alert("Error uploading file")
         })
-        setFiles(oldFiles => [...oldFiles, selectedFile.name])
     }
 
 

--- a/server/src/Controllers/transcriptUploadController.js
+++ b/server/src/Controllers/transcriptUploadController.js
@@ -10,13 +10,12 @@ router.post('/uploadTranscript', auth, upload.single('file'), async (req, res) =
     const file = req.file.buffer
     const filename = req.file.originalname
     try {
-        uploadTranscriptInteractor(user, file, filename)
+        await uploadTranscriptInteractor(user, file, filename)
+        res.sendStatus(200)
     }
     catch(e){
-        res.sendStatus(500)
-        console.log(e)
+        res.sendStatus("422")
     }
-    res.sendStatus(200)
 })
 
 module.exports = router

--- a/server/src/Controllers/transcriptUploadController.js
+++ b/server/src/Controllers/transcriptUploadController.js
@@ -14,7 +14,7 @@ router.post('/uploadTranscript', auth, upload.single('file'), async (req, res) =
         res.sendStatus(200)
     }
     catch(e){
-        res.sendStatus(422)
+        res.status(422).send(e.message)
     }
 })
 

--- a/server/src/Controllers/transcriptUploadController.js
+++ b/server/src/Controllers/transcriptUploadController.js
@@ -14,7 +14,7 @@ router.post('/uploadTranscript', auth, upload.single('file'), async (req, res) =
         res.sendStatus(200)
     }
     catch(e){
-        res.sendStatus("422")
+        res.sendStatus(422)
     }
 })
 

--- a/server/src/UseCases/TranscriptUseCases/transcriptUploadInteractor.js
+++ b/server/src/UseCases/TranscriptUseCases/transcriptUploadInteractor.js
@@ -23,50 +23,54 @@ const uploadTranscriptInteractor = async (user, file, filename) => {
 
 
     async function userSaveTranscriptAndIntents() {
-        const json = JSON.parse(file)
-        let allCurrentIntents = new Map()
-        if (user.intents !== undefined) {
-            allCurrentIntents = new Map(Object.entries(user.intents))
-        }
-
-        //single transcript processing
-        let intentsForThisFile = processTranscriptInteractor(new Map(), [json])
-
-        //multiple transcript processing
-        allCurrentIntents = processTranscriptInteractor(allCurrentIntents, [json])
-
-        addTranscriptToUser()
-        addIntentsToUser()
-        // just do one save: it will be obvious through the thrown errors if 
-        // there is an error in saving transcripts or intents
         try {
-            await user.save()
-        }
-        catch (e) {
-            throw new Error("Error in saving intents", e)
-        }
+            const json = JSON.parse(file)
+            let allCurrentIntents = new Map()
+            if (user.intents !== undefined) {
+                allCurrentIntents = new Map(Object.entries(user.intents))
+            }
 
-        function addIntentsToUser() {
+            //single transcript processing
+            let intentsForThisFile = processTranscriptInteractor(new Map(), [json])
+
+            //multiple transcript processing
+            allCurrentIntents = processTranscriptInteractor(allCurrentIntents, [json])
+
+            addTranscriptToUser()
+            addIntentsToUser()
+            // just do one save: it will be obvious through the thrown errors if 
+            // there is an error in saving transcripts or intents
             try {
-                user.intents = allCurrentIntents
-                // await user.save()
+                await user.save()
             }
             catch (e) {
                 throw new Error("Error in saving intents", e)
             }
-        }
 
-        function addTranscriptToUser() {
-            try {
-                const obj = {}
-                obj[filename] = file
-                obj["intents"] = intentsForThisFile
-                user.transcripts = user.transcripts.concat(obj)
-                // await user.save()        See comments at bottom re: only one save
+            function addIntentsToUser() {
+                try {
+                    user.intents = allCurrentIntents
+                    // await user.save()
+                }
+                catch (e) {
+                    throw new Error("Error in saving intents", e)
+                }
             }
-            catch (e) {
-                throw new Error("Error in saving transcripts", e)
+
+            function addTranscriptToUser() {
+                try {
+                    const obj = {}
+                    obj[filename] = file
+                    obj["intents"] = intentsForThisFile
+                    user.transcripts = user.transcripts.concat(obj)
+                    // await user.save()        See comments at bottom re: only one save
+                }
+                catch (e) {
+                    throw new Error("Error in saving transcripts", e)
+                }
             }
+        } catch (e) {
+            throw new Error("Invalid file format")
         }
     }
 }


### PR DESCRIPTION
Earlier, if the user uploads a file of the same name, they would see it on the dashboard even if the server was rejecting it. This was causing multiple errors on the client and the server being crashed. This is fixed now!

Another thing included in this PR is the bug where the server would crash if a file in incorrect format was uploaded (for eg. pdf). The same error messages is displayed in either cases.